### PR TITLE
JC-2073 Fixed problem with delayed deletion of comments

### DIFF
--- a/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/Post.hbm.xml
+++ b/jcommune-model/src/main/resources/org/jtalks/jcommune/model/entity/Post.hbm.xml
@@ -37,9 +37,9 @@
                      foreign-key="FK_USER" lazy="false" not-null="true" cascade="save-update"/>
         <many-to-one name="topic" column="TOPIC_ID" not-null="false"/>
         <!-- Where clause is used temporary. In future we may need load comments marked as deleted-->
+        <!--No caching here due problems with "WHERE" clause-->
         <bag name="comments" cascade="all-delete-orphan" inverse="true" order-by="CREATION_DATE"
              where="DELETION_DATE is null">
-            <cache usage="nonstrict-read-write"/>
             <key column="POST_ID" foreign-key="FK_COMMENT_POST"/>
             <one-to-many class="org.jtalks.jcommune.model.entity.PostComment"/>
         </bag>


### PR DESCRIPTION
Now cache is disabled on post-comment relation due problem with WHERE clause. If it is enabled hibernate ignores updates in comments
